### PR TITLE
Add one-command build/setup: Quick Start section in README [Generated by gurnben's Agent]

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,14 @@
 # service-status
 Project to harvest information about managed services and render it.
 
+## Quick Start
+
+```bash
+make build       # Build the service-status binary
+make test        # Run tests
+make clean       # Remove build artifacts
+```
+
 ## To use
 1. Extract github.com/ARO/ARO-HCP somewhere
 2. Log into quay using podman (yeah, doesn't work with docker)


### PR DESCRIPTION
## Summary

Adds one-command build/setup capability to improve developer onboarding and AI-assisted development.

### Changes

- **README.md** — added Quick Start section with `make` commands in a prominent position


### Why this matters

[AgentReady](https://github.com/ambient-code/agentready) checks for two things in the One-Command Build/Setup attribute:

1. A build automation tool exists (Makefile, setup script, etc.)
2. The setup command is documented **prominently in the README** (within the first few sections)

This PR addresses the documentation requirement — the Makefile already exists but setup instructions were not prominently placed in the README.

## AgentReady Score Impact

| Metric | Value |
|--------|-------|
| **Current score** | **23.8/100** (Needs Improvement) |
| **This PR** | **+3 points** |
| **Score after this PR** | **27/100** (Needs Improvement) |

### Attribute addressed

- One-Command Build/Setup (+3) — Tier 2 (Critical)

## Testing

- [ ] No functional code changes — documentation only
- [ ] Existing Makefile targets still work

---

> :robot_face: *This PR was generated by an AI agent* ([Claude](https://claude.ai)) as part of an organization-wide initiative to improve AI-assisted development readiness across `openshift-online`. The agent assessed all 32 public repositories using [AgentReady](https://github.com/ambient-code/agentready), identified improvement opportunities, generated the changes, and opened this PR. All commits are GPG-signed by [@gurnben](https://github.com/gurnben).
